### PR TITLE
fix: remove `--` from airbyte commands

### DIFF
--- a/tap_airbyte/tap.py
+++ b/tap_airbyte/tap.py
@@ -370,7 +370,6 @@ class TapAirbyte(Tap):
                 "run",
                 *(docker_args or []),
                 f"{self.image}:{self.tag}",
-                "--",
                 *airbyte_cmd,
             ]
         )


### PR DESCRIPTION
For non native airbyte sources (eg custom images we build), using `--` command is not valid. Airbyte throws this error:
`argument command: invalid choice: '--' (choose from 'spec', 'check', 'discover', 'read')`

https://5f61729d12784fa08328806da09f954a-dot-us-central1.composer.googleusercontent.com/log?execution_date=2024-06-20T12%3A00%3A00%2B00%3A00&task_id=run-meltano&dag_id=launch.ai-intercom-to-duckdb-Intercom--prod-3e7a3311-e261-4372-9dbc-51d2f4e266e5--81f221d3e0b1bff3bdbf73ad1cad573c4132f96ce527c669829e8652a3c1f331&map_index=-1